### PR TITLE
Consistent pointer types and allow non-default devices

### DIFF
--- a/examples/spectrum/src/main.rs
+++ b/examples/spectrum/src/main.rs
@@ -26,7 +26,7 @@ const WINDOW: usize = 2048;
 const FREQS_PER_COLUMN: usize = 20;
 
 fn main() {
-    let p = Record::new("Example", "Record", RATE);
+    let p = Record::new("Example", "Record", None, RATE);
     let mut plan = Plan::new(Operation::Forward, WINDOW);
 
     // Fill:

--- a/examples/tonegen/src/main.rs
+++ b/examples/tonegen/src/main.rs
@@ -7,7 +7,7 @@ use std::f64::consts::PI;
 const RATE: u32 = 48000;
 
 fn main() {
-    let p = Playback::new("Example", "Playback", RATE);
+    let p = Playback::new("Example", "Playback", None, RATE);
 
     // Generate 1s of sound
     let mut data = Vec::with_capacity(RATE as usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ struct SimpleClient<C: ChannelCount> {
 }
 
 impl<C: ChannelCount> SimpleClient<C> {
-    fn new(name: &str, desc: &str, dir: pa_stream_direction_t, dev: Option<&str>, rate: u32) -> Self {
+    fn new(name: &str, desc: &str, dir: pa_stream_direction_t, device: Option<&str>, rate: u32) -> Self {
         let ss = pa_sample_spec {
             format: C::format(),
             channels: C::count(),
@@ -101,7 +101,7 @@ impl<C: ChannelCount> SimpleClient<C> {
             pa_simple_new(null(),             // Use the default server.
                           name_c.as_ptr() as *const c_char,  // Our application's name.
                           dir,
-                          match dev {
+                          match device {
                               Some(ref d) => d.as_ptr() as *const c_char, // Device name to use
                               None => null() // Use the default device
                           },
@@ -132,9 +132,10 @@ pub struct Playback<C: ChannelCount> {
 }
 
 impl<C: ChannelCount> Playback<C> {
-    pub fn new(name: &str, desc: &str, dev: Option<&str>, rate: u32) -> Self {
+    /// Arguments: name, description, optional device (None uses the default device), and rate
+    pub fn new(name: &str, desc: &str, device: Option<&str>, rate: u32) -> Self {
         Playback {
-            client: SimpleClient::new(name, desc, PA_STREAM_PLAYBACK, dev, rate)
+            client: SimpleClient::new(name, desc, PA_STREAM_PLAYBACK, device, rate)
         }
     }
 
@@ -167,9 +168,10 @@ pub struct Record<C: ChannelCount> {
 }
 
 impl<C: ChannelCount> Record<C> {
-    pub fn new(name: &str, desc: &str, dev: Option<&str>, rate: u32) -> Self {
+    /// Arguments: name, description, optional device (None uses the default device), and rate
+    pub fn new(name: &str, desc: &str, device: Option<&str>, rate: u32) -> Self {
         Record {
-            client: SimpleClient::new(name, desc, PA_STREAM_RECORD, dev, rate)
+            client: SimpleClient::new(name, desc, PA_STREAM_RECORD, device, rate)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate libpulse_sys;
 extern crate libc;
 
+use libc::c_char;
 use libpulse_sys::*;
 use std::ptr::{null, null_mut};
 use std::mem::{transmute, size_of};
@@ -88,7 +89,7 @@ struct SimpleClient<C: ChannelCount> {
 }
 
 impl<C: ChannelCount> SimpleClient<C> {
-    fn new(name: &str, desc: &str, dir: pa_stream_direction_t, rate: u32) -> Self {
+    fn new(name: &str, desc: &str, dir: pa_stream_direction_t, dev: Option<&str>, rate: u32) -> Self {
         let ss = pa_sample_spec {
             format: C::format(),
             channels: C::count(),
@@ -98,10 +99,13 @@ impl<C: ChannelCount> SimpleClient<C> {
         let desc_c = CString::new(desc).unwrap();
         let s = unsafe {
             pa_simple_new(null(),             // Use the default server.
-                          name_c.as_ptr() as *const i8,  // Our application's name.
+                          name_c.as_ptr() as *const c_char,  // Our application's name.
                           dir,
-                          null(),             // Use the default device.
-                          desc_c.as_ptr() as *const i8,  // Description of our stream.
+                          match dev {
+                              Some(ref d) => d.as_ptr() as *const c_char, // Device name to use
+                              None => null() // Use the default device
+                          },
+                          desc_c.as_ptr() as *const c_char,  // Description of our stream.
                           &ss,                // Our sample format.
                           null(),             // Use default channel map
                           null(),             // Use default buffering attributes.
@@ -128,9 +132,9 @@ pub struct Playback<C: ChannelCount> {
 }
 
 impl<C: ChannelCount> Playback<C> {
-    pub fn new(name: &str, desc: &str, rate: u32) -> Self {
+    pub fn new(name: &str, desc: &str, dev: Option<&str>, rate: u32) -> Self {
         Playback {
-            client: SimpleClient::new(name, desc, PA_STREAM_PLAYBACK, rate)
+            client: SimpleClient::new(name, desc, PA_STREAM_PLAYBACK, dev, rate)
         }
     }
 
@@ -145,7 +149,7 @@ impl<C: ChannelCount> Playback<C> {
 
 #[test]
 fn test_playback() {
-    let p = Playback::new("Test", "Playback", 48000);
+    let p = Playback::new("Test", "Playback", None, 48000);
 
     // Generate sound
     let mut data = Vec::with_capacity(4800);
@@ -163,9 +167,9 @@ pub struct Record<C: ChannelCount> {
 }
 
 impl<C: ChannelCount> Record<C> {
-    pub fn new(name: &str, desc: &str, rate: u32) -> Self {
+    pub fn new(name: &str, desc: &str, dev: Option<&str>, rate: u32) -> Self {
         Record {
-            client: SimpleClient::new(name, desc, PA_STREAM_RECORD, rate)
+            client: SimpleClient::new(name, desc, PA_STREAM_RECORD, dev, rate)
         }
     }
 
@@ -180,7 +184,7 @@ impl<C: ChannelCount> Record<C> {
 
 #[test]
 fn test_record() {
-    let p = Record::new("Test", "Record", 48000);
+    let p = Record::new("Test", "Record", None, 48000);
 
     // Fill:
     let mut data = Vec::with_capacity(4800);


### PR DESCRIPTION
This PR just lets the library use libc's `c_char` instead of `i8` for pointers to be more consistent with the `libpulse-sys` library and make it more portable. In addition, it also allows a device name to be specialized when initializing a `Playback` or `Record`.
